### PR TITLE
Refactored class in SearchBox.cs

### DIFF
--- a/filemanager/Dialogs/SearchBox.cs
+++ b/filemanager/Dialogs/SearchBox.cs
@@ -2,91 +2,115 @@
 {
     public partial class SearchBox : Form
     {
-        public string ReturnValue { get; set; }
+        public string? ReturnValue { get; set; }
+        private const string searchResultCountFormatting = "[{0} files and {1} directories found]";
+        private IEnumerable<string> directorySearchResult = Empty();
+        private IEnumerable<string> fileSearchResult = Empty();
+        private enum SearchType
+        {
+            Files,
+            Directories
+        }
+
         public SearchBox(string searchInPath)
         {
             InitializeComponent();
             DoubleBuffering.SetDoubleBuffering(fileListView, true);
             searchInTextBox.Text = searchInPath;
-            pathSelectButton.Click += (sender, e) =>
+
+            pathSelectButton.Click += (s, e) => ApplySelectedPath();
+            cancelButton.Click += (s, e) => Cancel();
+            searchButton.Click += (s, e) => PerformSearch();
+            goToFileButton.Click += (s, e) => GoToSearchResult();
+        }
+
+        private void ApplySelectedPath()
+        {
+            if (folderBrowserDialog1.ShowDialog() == DialogResult.OK)
             {
-                if (folderBrowserDialog1.ShowDialog() == DialogResult.OK)
-                {
-                    searchInPath = folderBrowserDialog1.SelectedPath;
-                    searchInTextBox.Text = searchInPath;
-                }
+                searchInTextBox.Text = folderBrowserDialog1.SelectedPath;
+            }
+        }
+
+        private void Cancel()
+        {
+            DialogResult = DialogResult.Cancel;
+        }
+
+        private void GoToSearchResult()
+        {
+            if (fileListView.SelectedItems.Count > 0)
+            {
+                ReturnValue = fileListView.SelectedItems[0].Text;
+                DialogResult = DialogResult.OK;
+            }
+        }
+
+        private void PerformSearch()
+        {
+            var searchPath = searchInTextBox.Text;
+            var searchContent = searchForTextBox.Text;
+            if (string.IsNullOrEmpty(searchPath) || string.IsNullOrEmpty(searchContent))
+                return;
+
+            if (!searchExactCheck.Checked)
+                searchContent = $"*{searchContent}*";
+
+            if (includeDirsCheck.Checked)
+                directorySearchResult = GetSearchResults(searchPath, searchContent, SearchType.Directories);
+            
+            if (includeFilesCheck.Checked)
+                fileSearchResult = GetSearchResults(searchPath, searchContent, SearchType.Files);
+
+            PopulateSearchResultsList();
+        }
+
+        private IEnumerable<string> GetSearchResults(string searchInPath, string searchTarget, SearchType searchType)
+        {
+            EnumerationOptions options = new EnumerationOptions
+            {
+                MatchCasing = matchCaseCheck.Checked ? MatchCasing.CaseSensitive : MatchCasing.CaseInsensitive,
+                RecurseSubdirectories = includeSubdirs.Checked,
+                IgnoreInaccessible = true
             };
-            cancelButton.Click += (sender, e) => { this.DialogResult = DialogResult.Cancel; };
-            searchButton.Click += async (sender, e) =>
+
+            return searchType switch
             {
-                if (searchInTextBox.Text != "" && searchForTextBox.Text != "")
-                {
-                    DirectoryHandler directoryHandler = new DirectoryHandler();
-                    IEnumerable<string> directorySearchResult = Empty();
-                    IEnumerable<string> fileSearchResult = Empty();
-                    string searchTarget = searchForTextBox.Text;
-                    if (searchExactCheck.Checked == false) searchTarget = $"*{searchTarget}*";
-
-                    if (includeDirsCheck.Checked)
-                        directorySearchResult = System.IO.Directory.EnumerateDirectories(searchInTextBox.Text,
-                            searchTarget,
-                            new EnumerationOptions
-                            {
-                                RecurseSubdirectories = includeSubdirs.Checked,
-                                IgnoreInaccessible = true,
-                                MatchCasing = (matchCaseCheck.Checked) ? MatchCasing.CaseSensitive : MatchCasing.CaseInsensitive,
-                            });
-
-                    if (includeFilesCheck.Checked)
-                        fileSearchResult = System.IO.Directory.EnumerateFiles(searchInTextBox.Text,
-                            searchTarget,
-                            new EnumerationOptions
-                            {
-                                RecurseSubdirectories = includeSubdirs.Checked,
-                                IgnoreInaccessible = true,
-                                MatchCasing = (matchCaseCheck.Checked) ? MatchCasing.CaseSensitive : MatchCasing.CaseInsensitive,
-                            });
-
-                    fileListView.Clear();
-                    fileListView.Columns.Add($"[{fileSearchResult.Count()} files and {directorySearchResult.Count()} directories found]", -2);
-
-                    progressBar.Value = 0;
-                    progressBar.Maximum = directorySearchResult.Count() + fileSearchResult.Count();
-
-                    fileListView.BeginUpdate();
-                    if (fileSearchResult.Count() > 0)
-                    {
-                        foreach (string result in fileSearchResult)
-                        {
-                            fileListView.Items.Add(result);
-                            progressBar.Value++;
-                        }
-                    }
-
-                    if (directorySearchResult.Count() > 0)
-                    {
-                        foreach (string result in directorySearchResult)
-                        {
-                            fileListView.Items.Add(result);
-                            progressBar.Value++;
-                        }
-                    }
-                    fileListView.Columns[0].Width = -2;
-                    fileListView.EndUpdate();
-
-                    progressBar.Value = 0;
-                }
-            };
-            goToFileButton.Click += (sender, e) =>
-            {
-                if (fileListView.SelectedItems.Count > 0)
-                {
-                    ReturnValue = fileListView.SelectedItems[0].Text;
-                    DialogResult = DialogResult.OK;
-                }
+                SearchType.Files => System.IO.Directory.EnumerateFiles(searchInPath, searchTarget, options),
+                SearchType.Directories => System.IO.Directory.EnumerateDirectories(searchInPath, searchTarget, options),
+                _ => Enumerable.Empty<string>(),
             };
         }
-        public static IEnumerable<string> Empty()
+
+        private void PopulateSearchResultsList()
+        {
+            fileListView.Clear();
+            fileListView.Columns.Add(string.Format(searchResultCountFormatting, fileSearchResult.Count(), directorySearchResult.Count()));
+
+            int totalSearchResults = directorySearchResult.Count() + fileSearchResult.Count();
+            progressBar.Value = 0;
+            progressBar.Maximum = totalSearchResults;
+
+            fileListView.BeginUpdate();
+
+            foreach (var file in fileSearchResult)
+            {
+                fileListView.Items.Add(file);
+                progressBar.Value++;
+            }
+
+            foreach (var directory in directorySearchResult)
+            {
+                fileListView.Items.Add(directory);
+                progressBar.Value++;
+            }
+
+            fileListView.Columns[0].Width = -2;
+            fileListView.EndUpdate();
+            progressBar.Value = 0;
+        }
+
+        private static IEnumerable<string> Empty()
         {
             yield break;
         }


### PR DESCRIPTION
Changed code structure according to the recommendations.
Split responsibilities based on the possible user actions.

- Opening search dialog.
- Applying new search path.
- Opening result path.
- Enumerating files / directories.
- Populating search list.

Listed methods were added instead of anonymous delegate declaration.

Moved _directorySearchResult_ and _fileSearchResult_ variables to the class body.
Moved previously hardcoded format string to the separate static variable called _searchResultCountFormatting_.

Simplified conditional logic by splitting it between methods.
Replaced duplicated enumeration call with a new method.

Closes #3 