### PR TITLE
Refactored class in ExchangeBuffer.cs

### DIFF
--- a/filemanager/Handlers/DataProcessing/DirectoryHandler.cs
+++ b/filemanager/Handlers/DataProcessing/DirectoryHandler.cs
@@ -138,7 +138,7 @@
         {
             if (source.Count > 0)
             {
-                if (source.Count == 1 && source[0].ETag().Type == "utility") return;
+                if (source.Count == 1 && source[0].ETag().Type == Element.ElementType.Utility) return;
 
                 ExchangeBuffer buffer = new ExchangeBuffer();
                 string zipPath = Path.Combine(Path.GetDirectoryName(source[source.Count - 1].ETag().Path), $"temp-{DateTime.Now.Ticks}");
@@ -147,7 +147,7 @@
                 buffer.Copy(source);
                 buffer.Paste(zipPath);
 
-                string targetname = RecurringNames.GetExistingFileName($"{Path.Combine(zipPath, @"../")}" +
+                string targetname = RecurringNames.GetUniqueNameForExistingFile($"{Path.Combine(zipPath, @"../")}" +
                     $"{source[source.Count - 1].ETag().Name}", ".zip");
                 try { System.IO.Compression.ZipFile.CreateFromDirectory(zipPath, targetname); }
                 catch { NotificationHandler.invokeError(ErrorType.zipError); }

--- a/filemanager/Handlers/DataProcessing/DisplayHandler.cs
+++ b/filemanager/Handlers/DataProcessing/DisplayHandler.cs
@@ -188,7 +188,7 @@ namespace filemanager
         {
             if (ListView.SelectedItems.Count > 0)
             {
-                if (ListView.SelectedItems[0].ETag().Type != "utility")
+                if (ListView.SelectedItems[0].ETag().Type != Element.ElementType.Utility)
                 {
                     return true;
                 }
@@ -335,12 +335,12 @@ namespace filemanager
                 int totalDirectories = 0;
                 foreach (ListViewItem elem in ListView.SelectedItems)
                 {
-                    if (elem.ETag().Type == "file")
+                    if (elem.ETag().Type == Element.ElementType.File)
                     {
                         totalSize += ((File)elem.ETag()).GetSize();
                         totalFiles++;
                     }
-                    else if (elem.ETag().Type == "directory")
+                    else if (elem.ETag().Type == Element.ElementType.Directory)
                     {
                         if (((Directory)elem.ETag()).IgnoreListing == false)
                         {
@@ -368,7 +368,7 @@ namespace filemanager
                 dialog.Dispose();
                 foreach (ListViewItem item in ListView.Items)
                 {
-                    if (item.ETag().Type == "file")
+                    if (item.ETag().Type == Element.ElementType.File)
                         if (listed.Contains(item.ETag().Extension.Replace('.', ' ').Trim()))
                             item.Selected = value;
                 }
@@ -381,7 +381,7 @@ namespace filemanager
             {
                 List<Element> data = new List<Element>();
                 foreach (ListViewItem item in ListView.SelectedItems)
-                    if (item.ETag().Type != "utility") data.Add(item.ETag());
+                    if (item.ETag().Type != Element.ElementType.Utility) data.Add(item.ETag());
                 DialogMultiRename dialog = new DialogMultiRename(data);
                 dialog.ShowDialog();
             }
@@ -405,9 +405,9 @@ namespace filemanager
             if (!Focused) return;
             if (isSelected())
             {
-                if (ListView.SelectedItems[0].ETag().Type == "directory")
+                if (ListView.SelectedItems[0].ETag().Type == Element.ElementType.Directory)
                     ProcessCall.RunProcess("explorer.exe", ListView.SelectedItems[0].ETag().Path);
-                else if (ListView.SelectedItems[0].ETag().Type == "file")
+                else if (ListView.SelectedItems[0].ETag().Type == Element.ElementType.File)
                     ProcessCall.RunProcess("explorer.exe", Path.GetDirectoryName(ListView.SelectedItems[0].ETag().Path));
             }
         }

--- a/filemanager/Handlers/Mediator.cs
+++ b/filemanager/Handlers/Mediator.cs
@@ -97,17 +97,17 @@ namespace filemanager
             ListView.SelectedListViewItemCollection selected = Display.ListView.SelectedItems;
             if (selected.Count > 0)
             {
-                if (selected[0].ETag().Type == "utility")
+                if (selected[0].ETag().Type == Element.ElementType.Utility)
                 {
                     RootDirectory root = new RootDirectory("dir", Path.GetFullPath(Path.Combine(Display.RootDirectory.Path, @"..")));
                     GoTo(root);
                 }
-                else if (selected[0].ETag().Type == "directory")
+                else if (selected[0].ETag().Type == Element.ElementType.Directory)
                 {
                     RootDirectory root = new RootDirectory("dir", selected[0].ETag().Path);
                     GoTo(root);
                 }
-                else if (selected[0].ETag().Type == "file")
+                else if (selected[0].ETag().Type == Element.ElementType.File)
                 {
                     ((File)selected[0].Tag).View(associated);
                 }

--- a/filemanager/RuntimeEvents/QuickAccess.cs
+++ b/filemanager/RuntimeEvents/QuickAccess.cs
@@ -11,7 +11,7 @@
                 if (!Path.Exists(path)) System.IO.File.Create(path).Close();
                 foreach (ListViewItem lvi in mediator.GetSelectedItems())
                 {
-                    if (lvi.ETag().Type != "utility")
+                    if (lvi.ETag().Type != Element.ElementType.Utility)
                     {
                         quickAccessList.Items.Add((ListViewItem)lvi.Clone());
                         quickAccessList.Items[quickAccessList.Items.Count - 1].Tag = lvi.ETag();
@@ -27,11 +27,11 @@
             RootDirectory root;
             switch (selection.Type)
             {
-                case "directory":
+                case Element.ElementType.Directory:
                     root = new RootDirectory("dir", selection.Path);
                     mediator.GoTo(root);
                     break;
-                case "file":
+                case Element.ElementType.File:
                     root = new RootDirectory("dir", Path.GetDirectoryName(selection.Path));
                     mediator.GoTo(root);
                     ListViewItem target = mediator.GetSelectedItems().Cast<ListViewItem>()

--- a/filemanager/Statics/NullObjectCheck.cs
+++ b/filemanager/Statics/NullObjectCheck.cs
@@ -4,9 +4,9 @@
     {
         public static bool IsNull(Element obj)
         {
-            if (!Path.Exists(obj.Path) && obj.Type != "utility")
+            if (!Path.Exists(obj.Path) && obj.Type != Element.ElementType.Utility)
             {
-                NotificationHandler.invokeError(ErrorType.noObject, obj.Type, obj.Name);
+                NotificationHandler.invokeError(ErrorType.noObject, obj.Type.ToString(), obj.Name);
                 return true;
             }
             return false;

--- a/filemanager/Statics/RecurringNames.cs
+++ b/filemanager/Statics/RecurringNames.cs
@@ -2,7 +2,7 @@
 {
     public static class RecurringNames
     {
-        public static string GetExistingDirectoryName(string targetname)
+        public static string GetUniqueNameForExistingDirectory(string targetname)
         {
             int c = 1;
             string modname = targetname;
@@ -13,7 +13,7 @@
             }
             return modname;
         }
-        public static string GetExistingFileName(string targetname, string extension)
+        public static string GetUniqueNameForExistingFile(string targetname, string extension)
         {
             int c = 1;
             string modname = targetname;

--- a/filemanager/Structures/Units/Directory.cs
+++ b/filemanager/Structures/Units/Directory.cs
@@ -8,7 +8,7 @@
             Name = name;
             Path = path;
             IsHidden = false;
-            Type = "directory";
+            Type = ElementType.Directory;
             SubType = "directory";
             IgnoreListing = false;
         }

--- a/filemanager/Structures/Units/Element.cs
+++ b/filemanager/Structures/Units/Element.cs
@@ -4,7 +4,7 @@
     {
         public bool IgnoreListing { get; set; }
         public string Attributes { get; set; }
-        public string Type { get; set; }
+        public ElementType Type { get; set; }
         public string SubType { get; set; }
         public string Name { get; set; }
         public string Path { get; set; }
@@ -27,6 +27,12 @@
                 try { System.IO.Directory.Move(oldpath, newpath); }
                 catch(Exception ex) { if(!ignoreError) MessageBox.Show(ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error); }
             }
+        }
+        public enum ElementType {
+            Unknown,
+            Utility,
+            File,
+            Directory
         }
     }
 }

--- a/filemanager/Structures/Units/File.cs
+++ b/filemanager/Structures/Units/File.cs
@@ -12,11 +12,11 @@ namespace filemanager
             Path = path;
             Size = size;
             Extension = extension;
-            Type = "file";
+            Type = ElementType.File;
         }
         public File() 
         {
-            Type = "file";
+            Type = ElementType.File;
         }
         public void View(Dictionary<string, string> associated)
         {

--- a/filemanager/Structures/Units/FileTypes/ArchiveFile.cs
+++ b/filemanager/Structures/Units/FileTypes/ArchiveFile.cs
@@ -5,7 +5,7 @@
         public ArchiveFile() 
         {
             SubType = "archive";
-            Type = "file";
+            Type = ElementType.File;
         }
         public void Unzip()
         {

--- a/filemanager/Structures/Units/FileTypes/DocumentFile.cs
+++ b/filemanager/Structures/Units/FileTypes/DocumentFile.cs
@@ -7,7 +7,7 @@ namespace filemanager
         public DocumentFile()
         {
             SubType = "documentfile";
-            Type = "file";
+            Type = ElementType.File;
         }
         public void PrintDocument(string filePath, string printer)
         {

--- a/filemanager/Structures/Units/FileTypes/ImageFile.cs
+++ b/filemanager/Structures/Units/FileTypes/ImageFile.cs
@@ -8,7 +8,7 @@ namespace filemanager
         public int Height { get; set; }
         public ImageFile() { 
             SubType = "imagefile";
-            Type = "file";
+            Type = ElementType.File;
         }
         public override void Edit()
         {

--- a/filemanager/Structures/Units/FileTypes/UnknownFile.cs
+++ b/filemanager/Structures/Units/FileTypes/UnknownFile.cs
@@ -5,7 +5,7 @@
         public UnknownFile()
         {
             SubType = "unknownfile";
-            Type = "file";
+            Type = ElementType.File;
         }
     }
 }

--- a/filemanager/Structures/Units/Special/MovementDirectory.cs
+++ b/filemanager/Structures/Units/Special/MovementDirectory.cs
@@ -4,7 +4,7 @@
     {
         public MovementDirectory() 
         {
-            Type = "utility";
+            Type = ElementType.Utility;
             IgnoreListing = true;
         }
         public override void Delete() { }


### PR DESCRIPTION
Changed code structure according to the recommendations.
Fixed primitive obsession by changing _Type_ field in the Element class and its following inherited classes to enum:
- Directory
- Movement Directory
- File
- Archive File
- Document File
- Image File
- Unknown File

Changed condition logic accordingly in the following handlers:
- Display Handler
- Directory Handler
- Mediator

Simplified complex conditions by splitting up logic between methods:
Divided each file and directory operation by introducing move/copy methods ensuring better maintainability.

Renamed part of the variables to improve readability.

Closes #5 
